### PR TITLE
feat: add TypeScript typings builtin

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+package-lock=false
 save-exact = true

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "webpack.js",
     "license.md"
   ],
+  "typings": "./typings/index.d.ts",
   "scripts": {
     "build": "babel src --out-dir dist",
     "test": "ava",

--- a/readme.md
+++ b/readme.md
@@ -973,7 +973,7 @@ const Button = ({ children }) => (
 }
 ```
 
-### Syntax Highlighting [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=blanu.vscode-styled-jsx)
+### Syntax Highlighting [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=Divlo.vscode-styled-jsx-syntax)
 Launch VS Code Quick Open (⌘+P), paste the following command, and press enter.
 ```
 ext install Divlo.vscode-styled-jsx-syntax
@@ -984,7 +984,7 @@ If you use Stylus instead of plain CSS, install [vscode-styled-jsx-stylus](https
 ext install vscode-styled-jsx-stylus
 ```
 
-### Autocomplete [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=AndrewRazumovsky.vscode-styled-jsx-languageserver)
+### Autocomplete [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=Divlo.vscode-styled-jsx-languageserver)
 Launch VS Code Quick Open (⌘+P), paste the following command, and press enter.
 ```
 ext install Divlo.vscode-styled-jsx-languageserver

--- a/typings/css.d.ts
+++ b/typings/css.d.ts
@@ -1,0 +1,11 @@
+// Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
+
+declare function css(chunks: TemplateStringsArray, ...args: any[]): JSX.Element
+declare namespace css {
+  function global(chunks: TemplateStringsArray, ...args: any[]): JSX.Element
+  function resolve(
+    chunks: TemplateStringsArray,
+    ...args: any[]
+  ): { className: string; styles: JSX.Element }
+}
+export { css }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,13 @@
+// Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
+
+import 'react'
+
+export * from './server'
+export * from './css'
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    jsx?: boolean
+    global?: boolean
+  }
+}

--- a/typings/server.d.ts
+++ b/typings/server.d.ts
@@ -1,0 +1,11 @@
+// Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
+
+import { ReactElement } from 'react'
+
+declare function flushToHTML(opts?: { nonce?: string }): string
+declare function flushToReact<T>(opts?: {
+  nonce?: string
+}): Array<ReactElement<T>>
+
+export { flushToHTML }
+export default flushToReact


### PR DESCRIPTION
**What changes this PR introduce ?**
- Add TypeScript typings defintions builtin so users don't need anymore [@types/styled-jsx](https://www.npmjs.com/package/@types/styled-jsx)
See https://github.com/vercel/styled-jsx/issues/688#issuecomment-757352178.
- Disable `package-lock.json` in `.npmrc` since there wasn't a `package-lock.json` file
- Fix the little oversight of the previous time introduced in #670, where I updated the way to install the VSCode extension, but I forget to also update the links