### PR TITLE
fix(webpack): change webpack loader output to fix babel warnings

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -33,7 +33,7 @@ module.exports = function(content) {
     options.type = commentType[1]
   }
 
-  let output = `import css from 'styled-jsx/css';\n\nexport default css`
+  let output = `import css from 'styled-jsx/css';\n\nconst styles = css`
 
   if (options.type === 'global') {
     // css.global``
@@ -46,7 +46,10 @@ module.exports = function(content) {
 
   // Escape backticks and backslashes: “`” ⇒ “\`”, “\” ⇒ “\\”
   // (c) https://git.io/fNZzr
-  output += `\`${content.replace(/[`\\]/g, match => '\\' + match)}\``
+  output += `\`${content.replace(
+    /[`\\]/g,
+    match => '\\' + match
+  )}\`;\n\nexport default styles;`
 
   this.callback(null, output)
 }


### PR DESCRIPTION
Hi everyone!

This PR fixes [this issue](https://github.com/vercel/next.js/issues/14523) for this webpack plugin.
Meaning if you have another webpack plugin doing anonymous default export (like explained below), `@babel/plugin-transform-typescript` will still throw the warning.

### What is happening?
An anonymous default export of styled-jsx/css transpiled (by TypeScript) strings is causing the following warning:

```plaintext
The exported identifier "_defaultExport" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.
```

This is probably caused [by this code](https://github.com/babel/babel/pull/10174/files#diff-bf495cbf36bb1f7f76b1a9ce7840862a7ef1be5ac4db2349abc378a1f3990184R24) on the `@babel/plugin-transform-typescript` package.

### What does this PR do?

It simply creates a new variable, and then `export default` this new variable, so babel can get its scope.

```javascript
import css from 'styled-jsx/css';
const styles = css`...`;
export default styles;
```

As compared to the current code, which looks something like this:

```javascript
import css from 'styled-jsx/css';
export default css`...` // this causes the warning above
```

EDIT: This fix is for cases when you use a `style.css` file.
If you use `style.js` or `style.ts` file, consider the workaround given by the [linked issue](https://github.com/vercel/next.js/issues/14523)