### PR TITLE
Allow providing custom StyleSheetRegistry (fix async render issues)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "xo": "0.24.0"
   },
   "peerDependencies": {
-    "react": "15.x.x || 16.x.x || 17.x.x"
+    "react": "16.3 || 17"
   },
   "keywords": [
     "babel-plugin-macros",

--- a/server.d.ts
+++ b/server.d.ts
@@ -2,10 +2,22 @@
 
 import { ReactElement } from 'react'
 
-declare function flushToHTML(opts?: { nonce?: string }): string
-declare function flushToReact<T>(opts?: {
-  nonce?: string
-}): Array<ReactElement<T>>
+export declare class StyleSheetRegistry {
+  constructor()
 
-export { flushToHTML }
+  // These are marked private just so that we don't have to deal with specifying
+  // their return types (but they need to be here so that users don't just pass
+  // arbitrary objects in its place).
+  private cssRules()
+  private flush()
+}
+
+export interface FlushOpts {
+  nonce?: string
+  registry?: StyleSheetRegistry
+}
+
+export declare function flushToHTML(opts?: FlushOpts): string
+
+declare function flushToReact<T>(opts?: FlushOpts): Array<ReactElement<T>>
 export default flushToReact

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,18 @@
 import React from 'react'
 import { flush } from './style'
 
+import StyleSheetRegistry, {
+  StyleSheetRegistryContext,
+  globalStyleSheetRegistry
+} from './stylesheet-registry'
+export {
+  StyleSheetRegistry,
+  StyleSheetRegistryContext,
+  globalStyleSheetRegistry
+}
+
 export default function flushToReact(options = {}) {
-  return flush().map(args => {
+  return flush(options.registry).map(args => {
     const id = args[0]
     const css = args[1]
     return React.createElement('style', {
@@ -18,7 +28,7 @@ export default function flushToReact(options = {}) {
 }
 
 export function flushToHTML(options = {}) {
-  return flush().reduce((html, args) => {
+  return flush(options.registry).reduce((html, args) => {
     const id = args[0]
     const css = args[1]
     html += `<style id="__${id}"${

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -1,5 +1,6 @@
 import hashString from 'string-hash'
 import DefaultStyleSheet from './lib/stylesheet'
+import React from 'react'
 
 const sanitize = rule => rule.replace(/\/style/gi, '\\/style')
 export default class StyleSheetRegistry {
@@ -211,6 +212,11 @@ export default class StyleSheetRegistry {
     }, {})
   }
 }
+
+export const globalStyleSheetRegistry = new StyleSheetRegistry()
+export const StyleSheetRegistryContext = React.createContext(
+  globalStyleSheetRegistry
+)
 
 function invariant(condition, message) {
   if (!condition) {

--- a/test/index.js
+++ b/test/index.js
@@ -120,11 +120,14 @@ test('does not transpile nested style tags', async t => {
 })
 
 function clearModulesCache() {
-  ;['../src/lib/stylesheet', '../src/style', '../src/server'].forEach(
-    moduleName => {
-      delete require.cache[require.resolve(moduleName)]
-    }
-  )
+  ;[
+    '../src/lib/stylesheet',
+    '../src/style',
+    '../src/server',
+    '../src/stylesheet-registry'
+  ].forEach(moduleName => {
+    delete require.cache[require.resolve(moduleName)]
+  })
 }
 
 test('server rendering', t => {


### PR DESCRIPTION
Should fix #64 (while trying to keep existing workflows working and changing as few lines of code as possible).

# Changes
* Introduce `StyleSheetRegistryContext` (whose default value is `globalStyleSheetRegistry` -- means should work without changes for existing users who don't care about async rendering)
* Bump React requirement to 16.3 to get new context. (we **could** get around this if people feel strongly, but... React 16.3 should be a decent minimum in my _oh so humble_ opinion)

---

This is still somewhat of a WIP, but I think it's at the point that it could be review.