### PR TITLE
feat: use react hooks to manage styles injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "xo": "0.24.0"
   },
   "peerDependencies": {
-    "react": "15.x.x || 16.x.x || 17.x.x"
+    "react": "17.x.x || 18.x.x"
   },
   "keywords": [
     "babel-plugin-macros",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "xo": "0.24.0"
   },
   "peerDependencies": {
-    "react": "17.x.x || 18.x.x"
+    "react": ">= 16.8.0 || 17.x.x || 18.x.x"
   },
   "keywords": [
     "babel-plugin-macros",

--- a/src/style.js
+++ b/src/style.js
@@ -1,53 +1,30 @@
-import { Component } from 'react'
+import { useLayoutEffect } from 'react'
 import StyleSheetRegistry from './stylesheet-registry'
 
 const styleSheetRegistry = new StyleSheetRegistry()
 
-export default class JSXStyle extends Component {
-  constructor(props) {
-    super(props)
-    this.prevProps = {}
-  }
-
-  static dynamic(info) {
-    return info
-      .map(tagInfo => {
-        const baseId = tagInfo[0]
-        const props = tagInfo[1]
-        return styleSheetRegistry.computeId(baseId, props)
-      })
-      .join(' ')
-  }
-
-  // probably faster than PureComponent (shallowEqual)
-  shouldComponentUpdate(otherProps) {
-    return (
-      this.props.id !== otherProps.id ||
-      // We do this check because `dynamic` is an array of strings or undefined.
-      // These are the computed values for dynamic styles.
-      String(this.props.dynamic) !== String(otherProps.dynamic)
-    )
-  }
-
-  componentWillUnmount() {
-    styleSheetRegistry.remove(this.props)
-  }
-
-  render() {
-    // This is a workaround to make the side effect async safe in the "render" phase.
-    // See https://github.com/zeit/styled-jsx/pull/484
-    if (this.shouldComponentUpdate(this.prevProps)) {
-      // Updates
-      if (this.prevProps.id) {
-        styleSheetRegistry.remove(this.prevProps)
-      }
-
-      styleSheetRegistry.add(this.props)
-      this.prevProps = this.props
-    }
-
+export default function JSXStyle(props) {
+  if (typeof window === 'undefined') {
+    styleSheetRegistry.add(props)
     return null
   }
+  useLayoutEffect(() => {
+    styleSheetRegistry.add(props)
+    return () => {
+      styleSheetRegistry.remove(props)
+    }
+  }, [props.id, props.children, String(props.dynamic)])
+  return null
+}
+
+JSXStyle.dynamic = info => {
+  return info
+    .map(tagInfo => {
+      const baseId = tagInfo[0]
+      const props = tagInfo[1]
+      return styleSheetRegistry.computeId(baseId, props)
+    })
+    .join(' ')
 }
 
 export function flush() {

--- a/src/style.js
+++ b/src/style.js
@@ -13,7 +13,8 @@ export default function JSXStyle(props) {
     return () => {
       styleSheetRegistry.remove(props)
     }
-  }, [props.id, props.children, String(props.dynamic)])
+    // props.children can be string[], will be striped since id is identical
+  }, [props.id, String(props.dynamic)])
   return null
 }
 


### PR DESCRIPTION
StyleSheetRegistry is an external state outside of react, to keep sync with react internal state, we'd better use reliable lifecycle to count the change instead of use cached class properties and `render` function to determine changes.

### Lifecycle
first render -> add style
update -> remove then add
unmount -> remove

### Problem
the issue is the react internal state might be different with the cached class properties `this.prevProps`, react might drop some render due to prioritise change, leading to **tearing**.

### Notice
This PR only solved the effects issue when using the react under concurrent mode.
