### PR TITLE
chore: auto publish when merging to alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "xo": "0.24.0"
   },
   "peerDependencies": {
-    "react": "15.x.x || 16.x.x || 17.x.x"
+    "react": ">= 16.8.0 || 17.x.x || 18.x.x"
   },
   "keywords": [
     "babel-plugin-macros",


### PR DESCRIPTION
According to sematic release [preprelease](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/pre-releases.md#publishing-pre-releases) section, we can use `alpha` branch to ship prereleases

This commit including `BREAKING CHANGE`, will ship a pre major version as expected