### PR TITLE
feat: support ESM import syntax for plugins

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -468,7 +468,7 @@ export const combinePlugins = plugins => {
 
   combinedPluginsCache.plugins = pluginsToString
   combinedPluginsCache.combined = plugins
-    .map((plugin, i) => {
+    .map(async (plugin, i) => {
       let options = {}
       if (Array.isArray(plugin)) {
         options = plugin[1] || {}
@@ -483,7 +483,7 @@ export const combinePlugins = plugins => {
 
       log('Loading plugin from path: ' + plugin)
 
-      let p = require(plugin)
+      let p = await import(plugin)
       if (p.default) {
         p = p.default
       }


### PR DESCRIPTION
Currently, `styled-jsx` plugins can't be written with ESM imports syntax because it requires the import instead of using [dynamic import](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports) syntax.

Causing this error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/divlo/Documents/testing/app/node_modules/@styled-jsx/plugin-sass/index.js from /home/divlo/Documents/testing/app/node_modules/styled-jsx/dist/_utils.js not supported.
Instead change the require of index.js in /home/divlo/Documents/testing/app/node_modules/styled-jsx/dist/_utils.js to a dynamic import() which is available in all CommonJS modules.
```

As stated in the [Node.js documentation](https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_import_expressions)

> [Dynamic import()](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports) is supported in both CommonJS and ES modules. In CommonJS modules it can be used to load ES modules.

It is already included in Node.js v12, depending on what Node.js versions are you supporting, that could be a **BREAKING CHANGE**, if you're still supporting Node.js v10.

If you're supporting Node.js v12 and newer it is **not** a **BREAKING CHANGE**.

Related: https://github.com/Thream/styled-jsx-plugin-sass/issues/68 