### PR TITLE
perf: fallback to module level registry in browser

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -1,19 +1,22 @@
 import React from 'react'
-import { useStyleRegistry } from './stylesheet-registry'
+import { useStyleRegistry, createStyleRegistry } from './stylesheet-registry'
 import { computeId } from './lib/hash'
 
 // Opt-into the new `useInsertionEffect` API in React 18, fallback to `useLayoutEffect`.
 // https://github.com/reactwg/react-18/discussions/110
 const useInsertionEffect = React.useInsertionEffect || React.useLayoutEffect
+
+const isBrowser = typeof window !== 'undefined'
+const defaultRegistry = createStyleRegistry()
 export default function JSXStyle(props) {
-  const registry = useStyleRegistry()
+  const registry = isBrowser ? defaultRegistry : useStyleRegistry()
 
   // If `registry` does not exist, we do nothing here.
   if (!registry) {
     return null
   }
 
-  if (typeof window === 'undefined') {
+  if (!isBrowser) {
     registry.add(props)
     return null
   }


### PR DESCRIPTION
Fallback to module level local registry on client side, so we don't have to include a registry there.
`StyleRegistry` is only required for server render for safe concurrent rendering