### PR TITLE
fix: isBrowser false positives

### DIFF
--- a/src/lib/stylesheet.js
+++ b/src/lib/stylesheet.js
@@ -13,7 +13,7 @@ export default class StyleSheet {
   constructor({
     name = 'stylesheet',
     optimizeForSpeed = isProd,
-    isBrowser = typeof window !== 'undefined'
+    isBrowser = typeof document !== 'undefined'
   } = {}) {
     invariant(isString(name), '`name` must be a string')
     this._name = name

--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -22,7 +22,7 @@ export class StyleSheetRegistry {
   constructor({
     styleSheet = null,
     optimizeForSpeed = false,
-    isBrowser = typeof window !== 'undefined'
+    isBrowser = typeof document !== 'undefined'
   } = {}) {
     this._sheet =
       styleSheet ||


### PR DESCRIPTION
Feature detect against `document` instead of `window` to avoid false positives in environments like Deno that define a `window` global but no `document`