### PR TITLE
perf: Pre-compile dependencies to reduce install size/time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 
 # build output
 dist
+out
 
 # logs
 npm-debug.log

--- a/babel-test.js
+++ b/babel-test.js
@@ -1,2 +1,2 @@
 /* eslint-ignore */
-module.exports = require('./dist/babel-test')
+module.exports = require('./dist/babel').test()

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist')
+module.exports = require('./dist/index')

--- a/macro.js
+++ b/macro.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/macro')
+module.exports = require('./dist/babel').macro()

--- a/package.json
+++ b/package.json
@@ -20,11 +20,14 @@
   ],
   "typings": "./index.d.ts",
   "scripts": {
-    "build": "babel src --out-dir dist",
+    "build": "rm -rf dist && rm -rf out && babel src --out-dir out && yarn build-babel && yarn build-webpack && yarn build-index",
+    "build-babel": "ncc build out/babel.js -e react -e babel-plugin-macros --target es5 -o dist/babel",
+    "build-webpack": "ncc build out/webpack.js -e react -e babel-plugin-macros --target es5 -o dist/webpack",
+    "build-index": "ncc build out/index.js -e react -e babel-plugin-macros --target es5 -o dist/index",
     "test": "ava",
     "lint": "eslint ./src",
     "format": "prettier --write \"./{src,test}/**/*.{js,css}\"",
-    "prepublishOnly": "rm -rf dist && yarn build && yarn test && yarn lint --quiet"
+    "prepublishOnly": "yarn build && yarn test && yarn lint --quiet"
   },
   "husky": {
     "hooks": {
@@ -58,20 +61,11 @@
       "padding-line-between-statements": 0
     }
   },
-  "dependencies": {
-    "@babel/plugin-syntax-jsx": "7.14.5",
-    "@babel/types": "7.15.0",
-    "convert-source-map": "1.7.0",
-    "loader-utils": "1.2.3",
-    "source-map": "0.7.3",
-    "string-hash": "1.1.3",
-    "stylis": "3.5.4",
-    "stylis-rule-sheet": "0.0.10"
-  },
   "devDependencies": {
     "@babel/cli": "7.12.1",
     "@babel/core": "7.12.3",
     "@babel/plugin-proposal-object-rest-spread": "7.12.1",
+    "@babel/plugin-syntax-jsx": "7.14.5",
     "@babel/plugin-transform-arrow-functions": "7.12.1",
     "@babel/plugin-transform-modules-commonjs": "7.12.1",
     "@babel/plugin-transform-runtime": "7.12.1",
@@ -79,22 +73,33 @@
     "@babel/preset-react": "7.12.5",
     "@babel/register": "7.12.1",
     "@babel/runtime": "7.12.5",
+    "@babel/types": "7.15.0",
+    "@vercel/ncc": "0.33.1",
     "ava": "1.2.1",
     "babel-plugin-macros": "2.8.0",
+    "convert-source-map": "1.7.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "4.0.0",
     "husky": "4.3.0",
+    "loader-utils": "1.2.3",
     "prettier": "1.16.4",
     "pretty-quick": "3.1.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "semantic-release": "17.2.2"
+    "semantic-release": "17.2.2",
+    "source-map": "0.7.3",
+    "string-hash": "1.1.3",
+    "stylis": "3.5.4",
+    "stylis-rule-sheet": "0.0.10"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 || 17.x.x || 18.x.x"
   },
   "peerDependenciesMeta": {
     "@babel/core": {
+      "optional": true
+    },
+    "babel-plugin-macros": {
       "optional": true
     }
   },

--- a/src/babel.js
+++ b/src/babel.js
@@ -18,6 +18,14 @@ import {
 } from './_utils'
 import { STYLE_COMPONENT } from './_constants'
 
+export function macro() {
+  return require('./macro')
+}
+
+export function test() {
+  return require('./babel-test')
+}
+
 export default function({ types: t }) {
   const jsxVisitors = {
     JSXOpeningElement(path, state) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,5 @@ export {
   createStyleRegistry,
   useStyleRegistry
 } from './stylesheet-registry'
+
+export { default as style } from './style'

--- a/style.js
+++ b/style.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/style')
+module.exports = require('./dist/index').style

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,6 +1582,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@vercel/ncc@0.33.1":
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.33.1.tgz#b240080a3c1ded9446a30955a06a79851bb38f71"
+  integrity sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
This moves all dependencies to `devDependencies` by pre-compiling with `ncc` to reduce the install size and time. 

Before: `2.5M	styled-jsx-pre-ncc/node_modules`
After: `904K	styled-jsx-post-ncc/node_modules`

This removes 17 nested dependencies.

x-ref: https://github.com/vercel/next.js/pull/32742