### PR TITLE
chore: add type declaration file for `styled-jsx/macro`

### DIFF
--- a/macro.d.ts
+++ b/macro.d.ts
@@ -1,0 +1,11 @@
+declare namespace css {
+  function resolve(
+    chunks: TemplateStringsArray,
+    ...args: any[]
+  ): {
+    className: string
+    styles: JSX.Element
+  }
+}
+
+export = css


### PR DESCRIPTION
Because of the lack of the type declaration for `styled-jsx/macro`, I have to add these in my project when I use it with babel-macros. It would be great if this could be added to the package. 