### PR TITLE
fix: peer dep declaration for react 18 with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "stylis-rule-sheet": "0.0.10"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0 || 17.x.x || 18.x.x"
+    "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {


### PR DESCRIPTION
x-ref: https://github.com/vercel/next-react-server-components/issues/35

`18.x.x` seems to be treated as mismatch for react and react-dom with npm install, and then `styled-jsx` will be installed under `node_modules/next/node_modules` which leads to `styled-jsx/style` is not found.

yarn works fine