### PR TITLE
fix: including macro.d.ts to decalaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-test.js",
     "style.js",
     "macro.js",
+    "macro.d.ts",
     "css.js",
     "css.d.ts",
     "webpack.js",


### PR DESCRIPTION
Include macro.d.ts to files field in package.json
x-ref: #786