### PR TITLE
chore: remove git.io

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -45,7 +45,7 @@ module.exports = function(content) {
   // default css``
 
   // Escape backticks and backslashes: “`” ⇒ “\`”, “\” ⇒ “\\”
-  // (c) https://git.io/fNZzr
+  // (c) https://github.com/coox/styled-jsx-css-loader/blob/97a38e90dddf2c4b066e9247db0612c8f95302de/index.js#L6
   output += `\`${content.replace(
     /[`\\]/g,
     match => '\\' + match


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/