### PR TITLE
improvement: add typing for style imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel.js",
     "babel-test.js",
     "style.js",
+    "style.d.ts",
     "macro.js",
     "macro.d.ts",
     "css.js",

--- a/style.d.ts
+++ b/style.d.ts
@@ -1,0 +1,1 @@
+export default function JSXStyle(props: any): null


### PR DESCRIPTION
We can `styled-jsx/style` types import from styled-jsx instead of adding in nextjs