### PR TITLE
fix: declare module and fix conflict typing name

### DIFF
--- a/css.d.ts
+++ b/css.d.ts
@@ -1,11 +1,16 @@
 // Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
 
-declare function css(chunks: TemplateStringsArray, ...args: any[]): JSX.Element
-declare namespace css {
-  function global(chunks: TemplateStringsArray, ...args: any[]): JSX.Element
-  function resolve(
-    chunks: TemplateStringsArray,
-    ...args: any[]
-  ): { className: string; styles: JSX.Element }
+declare module 'styled-jsx/css' {
+  function css(chunks: TemplateStringsArray, ...args: any[]): JSX.Element
+  namespace css {
+    export function global(
+      chunks: TemplateStringsArray,
+      ...args: any[]
+    ): JSX.Element
+    export function resolve(
+      chunks: TemplateStringsArray,
+      ...args: any[]
+    ): { className: string; styles: JSX.Element }
+  }
+  export = css
 }
-export = css

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,18 +7,20 @@ declare module 'react' {
   }
 }
 
-export type StyleRegistry = {
-  styles(options?: { nonce?: string }): JSX.Element[]
-  flush(): void
-  add(props: any): void
-  remove(props: any): void
+declare module 'styled-jsx' {
+  export type StyledJsxStyleRegistry = {
+    styles(options?: { nonce?: string }): JSX.Element[]
+    flush(): void
+    add(props: any): void
+    remove(props: any): void
+  }
+  export function useStyleRegistry(): StyledJsxStyleRegistry
+  export function StyleRegistry({
+    children,
+    registry
+  }: {
+    children: JSX.Element | React.ReactNode
+    registry?: StyledJsxStyleRegistry
+  }): JSX.Element
+  export function createStyleRegistry(): StyledJsxStyleRegistry
 }
-export function useStyleRegistry(): StyleRegistry
-export function StyleRegistry({
-  children,
-  registry
-}: {
-  children: JSX.Element | React.ReactNode
-  registry?: StyleRegistry
-}): JSX.Element
-export function createStyleRegistry(): StyleRegistry

--- a/macro.d.ts
+++ b/macro.d.ts
@@ -1,11 +1,13 @@
-declare namespace css {
-  function resolve(
-    chunks: TemplateStringsArray,
-    ...args: any[]
-  ): {
-    className: string
-    styles: JSX.Element
+declare module 'styled-jsx/marco' {
+  namespace marco {
+    function resolve(
+      chunks: TemplateStringsArray,
+      ...args: any[]
+    ): {
+      className: string
+      styles: JSX.Element
+    }
   }
-}
 
-export = css
+  export = marco
+}

--- a/style.d.ts
+++ b/style.d.ts
@@ -1,1 +1,3 @@
-export default function JSXStyle(props: any): null
+declare module 'styled-jsx/style' {
+  export default function JSXStyle(props: any): null
+}


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/runs/7729014049?check_suite_focus=true

Add declare module and change type name from `StyleRegistry` to `StyledJsxStyleRegistry`

follow-up: will change the styled-jsx assets copy script in next.js