### PR TITLE
fix: tweak types

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="./css" />
+/// <reference types="./index" />
+/// <reference types="./macro" />
+/// <reference types="./style" />
+
+import React from 'react'
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    jsx?: boolean
+    global?: boolean
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,6 @@
-import React from 'react'
-
-declare module 'react' {
-  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
-    jsx?: boolean
-    global?: boolean
-  }
-}
-
 declare module 'styled-jsx' {
+  import React from 'react'
+
   export type StyledJsxStyleRegistry = {
     styles(options?: { nonce?: string }): JSX.Element[]
     flush(): void

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist",
     "lib",
+    "global.d.ts",
     "index.d.ts",
     "index.js",
     "babel.js",


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/pull/39474

`declare module` wasn't picked up by typescript


* Add `global.d.ts`
* Move react style types overriding into `global.d.ts`
* Scope react types in `index.d.ts`