### PR TITLE
fix: add displayName for context

### DIFF
--- a/src/stylesheet-registry.js
+++ b/src/stylesheet-registry.js
@@ -178,6 +178,7 @@ function invariant(condition, message) {
 }
 
 export const StyleSheetContext = createContext(null)
+StyleSheetContext.displayName = 'StyleSheetContext'
 
 export function createStyleRegistry() {
   return new StyleSheetRegistry()


### PR DESCRIPTION
Add `displayName` for registry for better visualization in devtools