### PR TITLE
feat: styled-jsx as client-only for rsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "ava": "4.3.1",
     "babel-plugin-macros": "2.8.0",
     "bunchee": "2.1.5",
-    "client-only": "0.0.1",
     "convert-source-map": "1.7.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "4.0.0",
@@ -123,5 +122,8 @@
     "zeit",
     "css-in-js",
     "css"
-  ]
+  ],
+  "dependencies": {
+    "client-only": "0.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/types": "7.15.0",
     "ava": "4.3.1",
     "babel-plugin-macros": "2.8.0",
-    "bunchee": "2.0.4",
+    "bunchee": "2.1.5",
     "client-only": "0.0.1",
     "convert-source-map": "1.7.0",
     "eslint": "7.32.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ava": "4.3.1",
     "babel-plugin-macros": "2.8.0",
     "bunchee": "2.0.4",
+    "client-only": "0.0.1",
     "convert-source-map": "1.7.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import 'client-only'
+
 export {
   StyleRegistry,
   createStyleRegistry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,10 +1432,10 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
-"@rollup/plugin-node-resolve@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
-  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
+"@rollup/plugin-node-resolve@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz#f2fa475405cd7fed6420bf438fe393f988a9bc96"
+  integrity sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -1443,14 +1443,6 @@
     is-builtin-module "^3.1.0"
     is-module "^1.0.0"
     resolve "^1.19.0"
-
-"@rollup/plugin-typescript@8.4.0":
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.4.0.tgz#a8a384b6dbaab42b4cafb075278b15743c0f5ef8"
-  integrity sha512-QssfoOP6V4/6skX12EfOW5UzJAv/c334F4OJWmQpe2kg3agEa0JwVCckwmfuvEgDixyX+XyxjFenH7M2rDKUyQ==
-  dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    resolve "^1.17.0"
 
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
@@ -1544,101 +1536,101 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@swc/core-android-arm-eabi@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.244.tgz#f45c5560a471b867f780ed9bd0799620ff8afd04"
-  integrity sha512-bQN6SY78bFIm6lz46ss4+ZDU9owevVjF95Cm+3KB/13ZOPF+m5Pdm8WQLoBYTLgJ0r4/XukEe9XXjba/6Kf8kw==
+"@swc/core-android-arm-eabi@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.6.tgz#0b127ccc7e6ea3e652e250afc3322d17aacec664"
+  integrity sha512-FQk/4cRRDoMPLgSm/1WvEqRqlSgBb6Twd5W13NYUbXJpzPGoPHhzwaCEbpGjPKG/OvAqA2NVrWquuJjhDvQyVQ==
   dependencies:
     "@swc/wasm" "1.2.122"
 
-"@swc/core-android-arm64@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.2.244.tgz#92d6cc1829d621fa1aa88d84d30a85112a82d148"
-  integrity sha512-CJeL/EeOIzrH+77otNT6wfGF8uadOHo4rEaBN/xvmtnpdADjYJ8Wt85X4nRK0G929bMke/QdJm5ilPNJdmgCTg==
+"@swc/core-android-arm64@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.3.6.tgz#9f0e76328ef35793157dfe84a40499a2f437981b"
+  integrity sha512-6qjZYatlFAN0IKhhYFsN+BaywooHFpK9/A/jMkjgIfbUoDz3wPJWZc2MDvcttgqZ+cfsSCcGeNw++H894z1zfw==
   dependencies:
     "@swc/wasm" "1.2.130"
 
-"@swc/core-darwin-arm64@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.244.tgz#7e068d14c357771f7ca23d7e1941e8bd577d2b5f"
-  integrity sha512-ZhRK8L/lpPCerUxtrW48cRJtpsUG5xVTUXu3N0TrYuxRzzapHgK+61g1JdtcwdNvEV7l00X4vfCBRYO0S2nsmw==
+"@swc/core-darwin-arm64@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.6.tgz#9a87819bf4879a165a7b4b868577f76dc94562e3"
+  integrity sha512-2qjaABxA7cloVTkS+uDEcVQ5buSi8de7qEv6P6InDE/iCjnI5ALyDxn7eauJJsVKimh9DyqN9sSZJ/z9U4FDUQ==
 
-"@swc/core-darwin-x64@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.2.244.tgz#bdf3c8150a3e18c392f3d30749a24f71bbd381cd"
-  integrity sha512-4mY8Gkq2ZMUpXYCLceGp7w0Jnxp75N1gQswNFhMBU4k90ElDuBtPoUSnB1v8MwlQtK7WA25MdvwFnBaEJnfxOg==
+"@swc/core-darwin-x64@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.6.tgz#804109765a69d8d7dab09d55f4bf0918254b3cf3"
+  integrity sha512-+OtW18d2o3RUuXodB41ZDj0iRCeXNL0OxVU0jTl7iyCWDypmCzhalbaQXD/ZJxgnpGRB7/s2ZwNR/gzjXgz9VA==
 
-"@swc/core-freebsd-x64@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.244.tgz#0941dd18745cc19ed35bc8b5f4c06f62fe91240d"
-  integrity sha512-k/NEZfkgtZ4S96woYArZ89jwJ/L1zyxihTgFFu7SxDt+WRE1EPmY42Gt4y874zi1JiSEFSRHiiueDUfRPu7C0Q==
+"@swc/core-freebsd-x64@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.6.tgz#f5450dede877f61cee427c1ea16165eb74fcfe36"
+  integrity sha512-f+ePNodn7ET9qEa93VMfnsPNnubWKIkn0EfxmfzJCt/abNVZ7+DyCSABfWKkexOZ8OuNyxnBCdKLL6nlizxkhQ==
   dependencies:
     "@swc/wasm" "1.2.130"
 
-"@swc/core-linux-arm-gnueabihf@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.244.tgz#e60536c2c7e858940138366d9438d33c80a119e3"
-  integrity sha512-tE9b/oZWhMXwoXHkgHFckMrLrlczvG7HgQAdtDuA6g30Xd/3XmdVzC4NbXR+1HoaGVDh7cf0EFE3aKdfPvPQwA==
+"@swc/core-linux-arm-gnueabihf@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.6.tgz#851871559363783818ee38725a6391b83ed3aff0"
+  integrity sha512-JwdJmqKzsdq7Itg5ssKDEY9mP3AkQ+XENF6WXXlaNu1U/InqQhD0DqsFzw4TQ4LzB7lB7Wj+dv3JjKIhnHNNag==
   dependencies:
     "@swc/wasm" "1.2.130"
 
-"@swc/core-linux-arm64-gnu@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.244.tgz#daa61051c971c30dd3bb5414be98ca7392b08c06"
-  integrity sha512-zrpVKUeQxZnzorOp3aXhjK1X2/6xuVZcdyxAUDzItP6G4nLbgPBEQLUi6aUjOjquFiihokXoKWaMPQjF/LqH+g==
+"@swc/core-linux-arm64-gnu@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.6.tgz#2afd9f3d4f2b051b79ed9f3549ccc8fa81ca6809"
+  integrity sha512-sRoPnwYFX+t95S7khi4KL2lZMZwbuzvPUf8NYmtTzfqVIseo8HD6IMgyeaQHYDfwDGF5elQGi4ALjRx2huSi0Q==
 
-"@swc/core-linux-arm64-musl@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.244.tgz#177ea7e8ba74309c2a08e165f147e63b7420a5d8"
-  integrity sha512-gI6bntk+HDe2witOsQgBDyDDpRmF5dfxbygvVsEdCI+Ko9yj5S9aCsc8WhhbtdcEG1Fo3v/sM/F/9pGatCAwzQ==
+"@swc/core-linux-arm64-musl@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.6.tgz#607cc220c8640f2d36e4e2426784a6a0fc55fa1e"
+  integrity sha512-XT8vRcxGaKujiplFfuMtGRgZ3Nx611TMVLUg91alzEIe2Adtrpaumzrwv2vqVdMr4X4GBK9z0rHsqkDLPhmuaw==
 
-"@swc/core-linux-x64-gnu@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.244.tgz#c4f00359567fdb25ab5616bf000168f4fcf30534"
-  integrity sha512-hwJ5HrDj7asmVGjzaT6SFdhPVxVUIYm9LCuE3yu89+6C5aR9YrCXvpgIjGcHJvEO2PLAtff72FsX7sbXbzzYGQ==
+"@swc/core-linux-x64-gnu@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.6.tgz#725386afc5092cf945245ba0d500f6fc1411efd9"
+  integrity sha512-nip81Ngcx8cory+FtapKhXb/rgh/pTAlvTiwJjMhsE3xcKRsbnJEPMVIoArCBV0BmYJBLWvOtpHf8B62JS7L5w==
 
-"@swc/core-linux-x64-musl@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.244.tgz#f4d07fbd6c73f54dfa351caf8263a81245882a1f"
-  integrity sha512-P8d4AIVN63xaS3t5WhOo0Ejy/X7XaDxXe9sJpEbGQP7CGofhURvgXwe8Q6uhPeWC9AwEPu35ArFQ0ZUmOCY0rg==
+"@swc/core-linux-x64-musl@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.6.tgz#b59ac6a51192713a500b81b558979e56761b5e0a"
+  integrity sha512-IzrQB67BY/rSZPJXWU3XzpkJqh4vYkYuOUmz1yrV/vxgPjJp/kUllfBYsHCiIedb7sjvfTt409SIN0FlPJY2+Q==
 
-"@swc/core-win32-arm64-msvc@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.244.tgz#38167a47c1cd8c73d0621a14d46b7982d1d314ff"
-  integrity sha512-PZUhgooqPDo+NUo+tIxWI1jKnYVV2ACs8eUkSE++Qf7E4/9Igy79XHbG4/G5ERlCudhdcw4XkYiRN8GJQg6P5w==
+"@swc/core-win32-arm64-msvc@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.6.tgz#50b7c16904f159dca5d4b29225dd55c11626ac95"
+  integrity sha512-gLsE/4qgqTxy0OOFJKi9QRs9mVYv4yOXSwPB2Rb+grOmNnG+Ds2LWqGEaABKDErnUtTQiOzLpdwesNZxeJgMhA==
   dependencies:
     "@swc/wasm" "1.2.130"
 
-"@swc/core-win32-ia32-msvc@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.244.tgz#7d6cb0ab95358dc56bd92ca85ac06687a732fa51"
-  integrity sha512-w7v8fND4E8wOHoVVNJIDjOh8EQiedI9HCsCTEDM/z/dVPsk/rxi6iHYnZG6gv+X/d0aCLeZQOkW9khfyy128cg==
+"@swc/core-win32-ia32-msvc@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.6.tgz#8e9d55586184b2a11978fe9dbc9a8a3a16d2e54a"
+  integrity sha512-0Jr7KMGEPapYGni+97oNOeVP7edBwjMGQ9HsJUUN1uIE7fALQ+zVGuwbc+22myql2Uhh5V5hZx5xtVraqLVMHw==
   dependencies:
     "@swc/wasm" "1.2.130"
 
-"@swc/core-win32-x64-msvc@1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.244.tgz#fed9dd48b3ac1269c7dc62e23fa875ec3f2356b4"
-  integrity sha512-/A9ssLtqXEQrdHnJ9SvZSBF7zQM/0ydz8B3p5BT9kUbAhmNqbfE4/Wy3d2zd7nrF16n6tRm4giCzcIdzd/7mvw==
+"@swc/core-win32-x64-msvc@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.6.tgz#a3c2bcf71b26cc4984adce4bfefb214664ce3b01"
+  integrity sha512-O3F/jxqaFwGq9XxYeCIVRCDIR4+GdSBu/5io6TkN8O5QLqB3/KOJVDn6TALtbL6ClwjUwZt66HKnYeSx19j2Ow==
 
-"@swc/core@^1.2.244":
-  version "1.2.244"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.2.244.tgz#d8ba46113c35f2e33dad6663ba8ce178542e24a3"
-  integrity sha512-/UguNMvKgVeR8wGFb53h+Y9hFSiEpeUhC4Cr1neN15wvWZD3lfvN4qAdqNifZiiPKXrCwYy8NTKlHVtHMYzpXw==
+"@swc/core@^1.3.5":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.6.tgz#909af865ee5044fe138ff85b40afb5d171d621a1"
+  integrity sha512-L3EemOWywrxXsRQFeU50PYFwrDKOxi2RGTT+TT3CcbIszwc7qnE6vsVzEll/eK32H1veicc0EegkZgtD4PFNRA==
   optionalDependencies:
-    "@swc/core-android-arm-eabi" "1.2.244"
-    "@swc/core-android-arm64" "1.2.244"
-    "@swc/core-darwin-arm64" "1.2.244"
-    "@swc/core-darwin-x64" "1.2.244"
-    "@swc/core-freebsd-x64" "1.2.244"
-    "@swc/core-linux-arm-gnueabihf" "1.2.244"
-    "@swc/core-linux-arm64-gnu" "1.2.244"
-    "@swc/core-linux-arm64-musl" "1.2.244"
-    "@swc/core-linux-x64-gnu" "1.2.244"
-    "@swc/core-linux-x64-musl" "1.2.244"
-    "@swc/core-win32-arm64-msvc" "1.2.244"
-    "@swc/core-win32-ia32-msvc" "1.2.244"
-    "@swc/core-win32-x64-msvc" "1.2.244"
+    "@swc/core-android-arm-eabi" "1.3.6"
+    "@swc/core-android-arm64" "1.3.6"
+    "@swc/core-darwin-arm64" "1.3.6"
+    "@swc/core-darwin-x64" "1.3.6"
+    "@swc/core-freebsd-x64" "1.3.6"
+    "@swc/core-linux-arm-gnueabihf" "1.3.6"
+    "@swc/core-linux-arm64-gnu" "1.3.6"
+    "@swc/core-linux-arm64-musl" "1.3.6"
+    "@swc/core-linux-x64-gnu" "1.3.6"
+    "@swc/core-linux-x64-musl" "1.3.6"
+    "@swc/core-win32-arm64-msvc" "1.3.6"
+    "@swc/core-win32-ia32-msvc" "1.3.6"
+    "@swc/core-win32-x64-msvc" "1.3.6"
 
 "@swc/wasm@1.2.122":
   version "1.2.122"
@@ -2137,20 +2129,20 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==
 
-bunchee@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/bunchee/-/bunchee-2.0.4.tgz#4dfea76194c927a39886daaf1c20c36382ef490a"
-  integrity sha512-G0E/cteucbJb/2zgR//Xm5awAdHOh6JxRz7zKD6t+lenEefLAPK6x5qj+84bAao6wZ1dDGWLqGWbS3SAAOs6DA==
+bunchee@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/bunchee/-/bunchee-2.1.5.tgz#815f55d2e857d9a647edd61130c513365e2415e5"
+  integrity sha512-ZRAqbX7pNx/S8wi/LjpUKdnQBOX9LpTbnZ2xhaVgvjBU4TlienMNxbqUcR2MZDzipo33ybBcyMdCp78uKGdnTw==
   dependencies:
     "@rollup/plugin-commonjs" "22.0.2"
     "@rollup/plugin-json" "4.1.0"
-    "@rollup/plugin-node-resolve" "13.3.0"
-    "@rollup/plugin-typescript" "8.4.0"
-    "@swc/core" "^1.2.244"
+    "@rollup/plugin-node-resolve" "14.1.0"
+    "@swc/core" "^1.3.5"
     arg "5.0.0"
-    rollup "2.74.1"
+    rollup "2.79.1"
+    rollup-plugin-dts "4.2.3"
     rollup-plugin-preserve-shebang "1.0.1"
-    rollup-plugin-swc3 "0.5.0"
+    rollup-plugin-swc3 "0.6.0"
     tslib "2.4.0"
 
 cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0, cacache@^15.3.0:
@@ -3331,6 +3323,11 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+get-tsconfig@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.2.0.tgz#ff368dd7104dab47bf923404eb93838245c66543"
+  integrity sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -3861,11 +3858,6 @@ java-properties@^1.0.0:
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
 
-joycon@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
-  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -3950,11 +3942,6 @@ json5@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
-
-jsonc-parser@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
-  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -4240,6 +4227,13 @@ magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
   integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
+magic-string@^0.26.6:
+  version "0.26.6"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.6.tgz#b61e417c9f40b7b53bf7e73c0a803258e20d25ee"
+  integrity sha512-6d+3bFybzyQFJYSoRsl9ZC0wheze8M1LrQC7tNMRqXR4izUTDOLMd9BtSuExK9iAukFh+s5K0WAhc/dlQ+HKYA==
   dependencies:
     sourcemap-codec "^1.4.8"
 
@@ -5568,6 +5562,15 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-dts@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-4.2.3.tgz#04c3615df1ffab4228aa9d540697eaca61e01f47"
+  integrity sha512-jlcpItqM2efqfIiKzDB/IKOS9E9fDvbkJSGw5GtK/PqPGS9eC3R3JKyw2VvpTktZA+TNgJRMu1NTv244aTUzzQ==
+  dependencies:
+    magic-string "^0.26.6"
+  optionalDependencies:
+    "@babel/code-frame" "^7.18.6"
+
 rollup-plugin-preserve-shebang@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-preserve-shebang/-/rollup-plugin-preserve-shebang-1.0.1.tgz#17109cdb4ed12c3cac9379b802182427cdbee5a1"
@@ -5575,20 +5578,19 @@ rollup-plugin-preserve-shebang@1.0.1:
   dependencies:
     magic-string "^0.25.7"
 
-rollup-plugin-swc3@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-swc3/-/rollup-plugin-swc3-0.5.0.tgz#caf745811d1377226ebb41e368eb0a38c70a30c1"
-  integrity sha512-Y5zJAsvksM39YAmjNje9rWtRMrJefaieDfkv52B2H7PsFj9EuYsrgGJRRUZCiOjMkQwdkiAEYfobqMZFV1X6pg==
+rollup-plugin-swc3@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-swc3/-/rollup-plugin-swc3-0.6.0.tgz#c9db634bd0d7f3d11e617a76f5e66847330d06dd"
+  integrity sha512-nNG2T3x3wq6e7H+8ZHB0CxJ3H9QeYZUh+DwCjwWEyGCaIwIMyIaq/30ZJlYK8/OWWhCfYMwxKRcZGirPg6nPqA==
   dependencies:
     "@rollup/pluginutils" "^4.2.1"
     deepmerge "^4.2.2"
-    joycon "^3.1.1"
-    jsonc-parser "^3.2.0"
+    get-tsconfig "^4.2.0"
 
-rollup@2.74.1:
-  version "2.74.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.74.1.tgz#4fba0ff1c312cc4ee82691b154eee69a0d01929f"
-  integrity sha512-K2zW7kV8Voua5eGkbnBtWYfMIhYhT9Pel2uhBk2WO5eMee161nPze/XRfvEQPFYz7KgrCCnmh2Wy0AMFLGGmMA==
+rollup@2.79.1:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2353,6 +2353,11 @@ cli-truncate@^3.1.0:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
 
+client-only@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"


### PR DESCRIPTION
Use `import "client-only"` to mark styled-jsx as client only packages for server components, so that when users try to import it on server layer it will error in next.js


Expected error if you use styled-jsx in server components rather than client components
> error - ../../../node_modules/.pnpm/client-only@0.0.1/node_modules/client-only/error.js (1:6) @ eval
error - Error: This module cannot be imported from a Server Component module. It should only be used from a Client Component.
    at eval (webpack-internal:///(sc_server)/../../../../node_modules/.pnpm/client-only@0.0.1/node_modules/client-only/error.js:1:7)


x-ref: https://github.com/vercel/next.js/pull/41414