### PR TITLE
docs: clarify :global()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -943,7 +943,7 @@ export default () => (
 )
 ```
 
-Please keep in mind that `:global()` styles will affect the entire subtree, so in many cases you may want to be careful and use the children (direct descendant) selector `>`.
+Please keep in mind that if omitting `>` before `:global()` in the above example, `:global()` styles will affect the entire subtree, so in many cases you may want to be careful and use the children (direct descendant) selector `>`.
 
 ### Build a component library with styled-jsx
 


### PR DESCRIPTION
Hi, please check this issue: "[:global rules style elements outside of subtree](https://github.com/vercel/styled-jsx/issues/718)".  I had the exact same confusion, but I might understand now. I leaved a  [comment](https://github.com/vercel/styled-jsx/issues/718#issuecomment-1294364804) describing my understanding.

Maybe a PR will help others to not get the same confusion as I did :) 