### PR TITLE
Add test case for `@container` query

### DIFF
--- a/test/styles.js
+++ b/test/styles.js
@@ -169,6 +169,7 @@ test('splits rules for `optimizeForSpeed`', t => {
     a, div { color: red }
     @import "./test.css";
     @media (min-width: 400px) { div, span { color: red } }
+    @container (min-width: 400px) { span { color: red } }
   `,
     [
       '@import "./test.css";',
@@ -176,7 +177,8 @@ test('splits rules for `optimizeForSpeed`', t => {
       '@supports (display:-webkit-box) or (display:-webkit-flex) or (display:-ms-flexbox) or (display:flex){div{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}}',
       'div{color:red;}',
       'a,div{color:red;}',
-      '@media (min-width:400px){div,span{color:red;}}'
+      '@media (min-width:400px){div,span{color:red;}}',
+      '@container (min-width:400px){span{color:red;}}'
     ]
   )
 


### PR DESCRIPTION
This test fails. I think it's because `@container` is only supported in the most recent version of Stylis ([issue](https://github.com/thysultan/stylis/issues/303)) but styled-jsx uses an old version of Stylis. 

I'm looking into how hard it would be to update Stylis to the newest version...