### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,12 @@
-👋 friend. Welcome to styled-jsx and thanks for contributing!
+<!--
 
-⚠️ IMPORTANT ⚠️
-
-If you need help or have a question about styled-jsx please ask it on Spectrum https://spectrum.chat/styled-jsx or join our Slack community at https://vercel.chat and ask it in the `#next` channel.
-
-Before you open a new issue please take a look at our [**Frequent Asked Questions**](https://github.com/vercel/styled-jsx#faq) and [**open issues**](https://github.com/vercel/styled-jsx/issues).
+Before you open a new issue please take a look at our [**Frequent Asked Questions**](https://github.com/vercel/styled-jsx#faq) and [**open issues**](https://github.com/vercel/styled-jsx/issues). Or if you're using styled-jsx with Next.js but found issue there, please fill an issue to [**Next.js**](https://github.com/verce/next.js/issues) instead.
 
 Remember, often time asking in chat or looking at the FAQ/issues can be \*faster than waiting for us to reply to a new issue\*\*.
 
 If you are here to report a bug or request a feature please remove this introductory section and fill out the information below!
 
----
+-->
 
 #### Do you want to request a _feature_ or report a _bug_?
 


### PR DESCRIPTION
* Remove outdated chat links information 
* Comment the welcome message, you can still see it but won't show up as the issue content

Addressing https://github.com/vercel/styled-jsx/issues/685#issuecomment-1753298125
