### PR TITLE
Bugfix: handle undefined <style> tag attr.name

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -124,7 +124,7 @@ export const isGlobalEl = el =>
 export const isStyledJsx = ({ node: el }) =>
   t.isJSXElement(el) &&
   el.openingElement.name.name === 'style' &&
-  el.openingElement.attributes.some(attr => attr.name.name === STYLE_ATTRIBUTE)
+  el.openingElement.attributes.some(({ name }) => name && name.name === STYLE_ATTRIBUTE)
 
 export const findStyles = path => {
   if (isStyledJsx(path)) {


### PR DESCRIPTION
I've faced an issue when `attr.name` was undefined.
For example when spreading an object inside the `<style>` tag like this:
```
<style {...(key && { key })} />
```
I got an error on the Storybook build:
```
Module build failed (from ./node_modules/babel-loader/lib/index.js):
TypeError: /home/lucas/project-name/src/utils/withStyles.tsx: Cannot read properties of undefined (reading 'name')
    at /home/lucas/project-name/storybook/node_modules/styled-jsx/dist/babel/index.js:21535:26
```
And in the debugger:
```
Exception has occurred: TypeError: Cannot read properties of undefined (reading 'name')
  at /home/lucas/DEV/project-name/storybook/node_modules/styled-jsx/dist/babel/index.js:21535:26
```

I have applied the same fix as the one in `isGlobalEl` function from `JJ Kasper (January 6th, 2019 6:09 PM)`.

Sorry, if I should create an issue first ;)