### PR TITLE
fix: bump peer dep for react 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "stylis-rule-sheet": "0.0.10"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+    "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {


### PR DESCRIPTION
Bump React peer dependency for react 19

![image](https://github.com/vercel/styled-jsx/assets/4800338/c1dad7a1-2f6b-4b09-9376-f9bd81017803)
