### PR TITLE
fix: Use scoped JSX namespace

### DIFF
--- a/css.d.ts
+++ b/css.d.ts
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 // Definitions by: @types/styled-jsx <https://www.npmjs.com/package/@types/styled-jsx>
 
 declare module 'styled-jsx/css' {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 /// <reference types="./css" />
 /// <reference types="./macro" />
 /// <reference types="./style" />

--- a/macro.d.ts
+++ b/macro.d.ts
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 declare module 'styled-jsx/macro' {
   namespace macro {
     function resolve(


### PR DESCRIPTION
The global one is removed in React 19 types and deprecated in 18.

It was backported down to React 15 types.