### PR TITLE
fix: Move TypeScript to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "source-map": "0.7.3",
     "string-hash": "1.1.3",
     "stylis": "3.5.4",
-    "stylis-rule-sheet": "0.0.10"
+    "stylis-rule-sheet": "0.0.10",
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
@@ -126,7 +127,6 @@
     "css"
   ],
   "dependencies": {
-    "client-only": "0.0.1",
-    "typescript": "~5.0.0"
+    "client-only": "0.0.1"
   }
 }


### PR DESCRIPTION
silly mistake